### PR TITLE
Recompile errors without adding -fPIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PredictWrapper.h: PredictWrapper.class
 	javah PredictWrapper
 
 $(LIBNAME): wrapper.c PredictWrapper.h model/model.c
-	gcc -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/$(INCNAME)" -I"$(PWD)/model" -shared -o $(LIBNAME) wrapper.c model/model.c
+	gcc -fPIC -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/$(INCNAME)" -I"$(PWD)/model" -shared -o $(LIBNAME) wrapper.c model/model.c
 
 clean:
 	rm -rfv org $(LIBNAME) PredictWrapper.h *.class


### PR DESCRIPTION
make error:
=============
...
javah PredictWrapper
gcc -I"/usr/lib/jvm/java-8-openjdk-amd64//include" -I"/usr/lib/jvm/java-8-openjdk-amd64//include/linux" -I"/home/ubuntu/treelite-jni-example/model" -shared -o libwrapper.so wrapper.c model/model.c
/usr/bin/ld: /tmp/ccjvVwEG.o: relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/tmp/ccjvVwEG.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:30: recipe for target 'libwrapper.so' failed
make: *** [libwrapper.so] Error 1

after adding -fPIC, make successfully
==============
ubuntu@ip-10-30-135-10:~/treelite-jni-example$ vim Makefile
ubuntu@ip-10-30-135-10:~/treelite-jni-example$ make
gcc -fPIC -I"/usr/lib/jvm/java-8-openjdk-amd64//include" -I"/usr/lib/jvm/java-8-openjdk-amd64//include/linux" -I"/home/ubuntu/treelite-jni-example/model" -shared -o libwrapper.so wrapper.c model/model.c
javac SimpleServer.java